### PR TITLE
fix(backend): redirect to correct base docs url

### DIFF
--- a/src/backend/api/src/app.rs
+++ b/src/backend/api/src/app.rs
@@ -106,10 +106,7 @@ impl Application {
 
         router
             .merge(SwaggerUi::new("/docs").url("/docs/openapi.json", api.clone()))
-            .route(
-                "/",
-                get(|| async { Redirect::permanent("/docs/swagger-ui") }),
-            )
+            .route("/", get(|| async { Redirect::permanent("/docs") }))
             .layer(TimeoutLayer::new(Duration::from_secs(30)))
             .layer(
                 ServiceBuilder::new()


### PR DESCRIPTION
Before this change the backend API was redirecting the wrong base url for the docs by default.

This now ensures it redirects to the valid url.